### PR TITLE
feat: add basic frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The server will start on port 3000 (or the port specified in the `PORT` environm
 
 Todos are stored in memory and will reset each time the server restarts.
 
+### Frontend
+
+A minimal frontend is available. After starting the server, open `http://localhost:3000/` in your browser to manage todos.
+
 ### Example
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(express.json());
+app.use(express.static('public'));
 
 // In-memory store for todos
 let todos = [];

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Todo App</title>
+</head>
+<body>
+  <h1>Todo App</h1>
+  <form id="new-todo-form">
+    <input type="text" id="new-todo-title" placeholder="What needs to be done?" required />
+    <button type="submit">Add Todo</button>
+  </form>
+  <ul id="todo-list"></ul>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,48 @@
+async function fetchTodos() {
+  const res = await fetch('/todos');
+  const data = await res.json();
+  renderTodos(data);
+}
+
+function renderTodos(todos) {
+  const list = document.getElementById('todo-list');
+  list.innerHTML = '';
+  todos.forEach(todo => {
+    const li = document.createElement('li');
+    const span = document.createElement('span');
+    span.textContent = todo.title;
+    if (todo.completed) {
+      span.style.textDecoration = 'line-through';
+    }
+    span.addEventListener('click', () => toggleTodo(todo.id));
+    li.appendChild(span);
+    list.appendChild(li);
+  });
+}
+
+async function addTodo(title) {
+  await fetch('/todos', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title })
+  });
+  fetchTodos();
+}
+
+async function toggleTodo(id) {
+  await fetch(`/todos/${id}/toggle`, { method: 'POST' });
+  fetchTodos();
+}
+
+const form = document.getElementById('new-todo-form');
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const input = document.getElementById('new-todo-title');
+  const title = input.value.trim();
+  if (title) {
+    addTodo(title);
+    input.value = '';
+  }
+});
+
+window.addEventListener('DOMContentLoaded', fetchTodos);


### PR DESCRIPTION
## Summary
- serve static files from `public` and add minimal HTML UI
- implement browser-based todo interactions via fetch
- document frontend usage in README

## Testing
- `npm test`
- `npm start >/tmp/server.log 2>&1 &` (then `kill 4340`)


------
https://chatgpt.com/codex/tasks/task_e_68c72a143a5083249869d69c0fc27542